### PR TITLE
modal forms was broken with new versions of jquery

### DIFF
--- a/assets/js/kb-modal-ajax.js
+++ b/assets/js/kb-modal-ajax.js
@@ -69,7 +69,7 @@
      */
     ModalAjax.prototype.injectHtml = function(html) {
         // Find form and inject it
-        var form = jQuery(html).filter('form');
+        var form = jQuery(html).find('form');
 
         // Remove existing forms
         if (jQuery(this.element).find('form').length > 0) {
@@ -158,6 +158,7 @@
                 if (contentType.indexOf('html') > -1) {
                     // Assume form contains errors if html
                     this.injectHtml(data);
+                    status = false;
                 }
                 jQuery(this.element).triggerHandler('kbModalSubmit', [data, status, xhr]);
             }


### PR DESCRIPTION
This one returned nothing:
`jQuery(html).filter('form');`
Changed it to this one, works fine now:
`jQuery(html).find('form');`
