### PR TITLE
Fix Bootstrap and Datepicker show.bs.modal conflict

### DIFF
--- a/assets/js/kb-modal-ajax.js
+++ b/assets/js/kb-modal-ajax.js
@@ -36,7 +36,7 @@
     ModalAjax.prototype.init = function(options) {
         this.initalRequestUrl = options.url;
         this.ajaxSubmit = options.ajaxSubmit || true;
-        jQuery(this.element).on('show.bs.modal', this.shown.bind(this));
+        jQuery(this.element).on('shown.bs.modal', this.shown.bind(this));
     };
 
     /**


### PR DESCRIPTION
Fix the conflict with Bootstrap and Bootstrap-datepicker show.bs.modal event.

Original issue: https://github.com/uxsolutions/bootstrap-datepicker/issues/978